### PR TITLE
Fix placeholder in README Demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flutter を使った **Web アプリ開発の検証用サンドボックス**で
 
 ## Demo
 
-https://ユーザー名.github.io/flutter-web-sandbox/
+https://<your-username>.github.io/flutter-web-sandbox/
 
 ---
 


### PR DESCRIPTION
Demo URLのプレースホルダーを `ユーザー名` から `<your-username>` に修正しました。